### PR TITLE
Use mtl-style Monad Stack for evaluator

### DIFF
--- a/hs/hs.cabal
+++ b/hs/hs.cabal
@@ -37,7 +37,7 @@ executable hs-exe
 
     -- Other library packages from which modules are imported.
     build-depends:
-          base ^>=4.14.3.0
+          base
         , hs
 
     -- Directories containing source files.
@@ -50,4 +50,4 @@ library
     hs-source-dirs: src
     exposed-modules: Model.Model, Evaluator.Evaluator, Evaluator.EvaluationContext
     build-depends:
-          base ^>=4.14.3.0
+          base

--- a/hs/hs.cabal
+++ b/hs/hs.cabal
@@ -51,3 +51,4 @@ library
     exposed-modules: Model.Model, Evaluator.Evaluator, Evaluator.EvaluationContext
     build-depends:
           base
+        , mtl

--- a/hs/src/Evaluator/EvaluationContext.hs
+++ b/hs/src/Evaluator/EvaluationContext.hs
@@ -3,7 +3,7 @@ module Evaluator.EvaluationContext where
 import Data.List.NonEmpty
 import Model.Model
 
-newtype Error = Error String deriving (Show)
+newtype Error = Error String deriving (Show, Eq)
 
 -- TODO : implementer source
 data GlobalContext = GlobalContext {fonctions :: [Fonction], source :: Int}


### PR DESCRIPTION
The monad stack used throughout the evaluator was explicitly being passed (and used!) inside the evaluator logic. This commits pulls the evaluator stack outside of the evaluator (and into Program). _mtl-style_ is much more readable, since we don't have to traverse the monad stack constructors to access and leave representation states.

This refactor revealed a potentially dangerous encoding of programs into evaluation context (see `runProgramInEval`); this function uses the implementation detail of the monad stack to interpret any program. A better implementation would model the explicit effects one wishes to allow instead. A quick view reveals that using a program at all in this case may be unneeded, but a deeper look at use-sites is needed.

The `liftEither` expression was introduced as a band-aid to adapt functions on other modules using the previous explicit stack API. I did not take the time to look whether they can all be 'simply' translated to `EvalContext`.